### PR TITLE
use setuptools instead of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import re
-from distutils.core import setup
+from setuptools import setup
 
 # Synchronize version from code.
 version = re.findall(r"__version__ = \"(.*?)\"", open("nestle.py").read())[0]


### PR DESCRIPTION
Switch from distutils to setuptools in `setup.py` so that one can install in development mode with `python setup.py develop`.

