### PR TITLE
Remove deprecation warning

### DIFF
--- a/nestle.py
+++ b/nestle.py
@@ -123,7 +123,7 @@ def resample_equal(samples, weights, rstate=None):
     # make N subdivisions, and choose positions with a consistent random offset
     positions = (rstate.random() + np.arange(N)) / N
 
-    idx = np.zeros(N, dtype=np.int)
+    idx = np.zeros(N, dtype=int)
     cumulative_sum = np.cumsum(weights)
     i, j = 0, 0
     while i < N:


### PR DESCRIPTION
Hi @kbarbary I'm not sure if you're actively maintaining this project anymore, but I'm seeing a deprecation warning from `numpy`. It's a fairly trivial fix, so it would be great to get a new release in order to make sure the package doesn't get clobbered by a future release of `numpy`.

FYI, I'm a maintainer of [Bilby](https://git.ligo.org/lscsoft/bilby) which supports nestle, and I know that it is a popular choice for many problems.